### PR TITLE
Changing "Genailes" -> "Me gusta"

### DIFF
--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -8,7 +8,7 @@
     "notifications": "Notificaciones",
     "go_back": "Atrás",
     "back": "Volver",
-    "yeahs": "Geniales",
+    "yeahs": "Me gusta",
     "more": "Cargar más publicaciones",
     "no_posts": "No hay publicaciones",
     "private": "Privado",


### PR DESCRIPTION
For propouses of neutrality and grammar I propouse this change.
"Geniales" is a **Plural** word, and in the most Hispanic countries this expression is little rare.
"Me gusta" is an expression for **Non-Plural and Plural expressions**, and it's most normal in Spanish