### PR TITLE
Adding the option to ban by also setting the time on Juxtaposition instead of just a date

### DIFF
--- a/src/webfiles/web/moderate_user.ejs
+++ b/src/webfiles/web/moderate_user.ejs
@@ -129,7 +129,7 @@
 				</div>
 				<div class="col">
 					<label for="ban_date">Banned Until:</label>
-					<input type="date" id="ban_lift_date" name="ban_lift_date" value="<%= userSettings.ban_lift_date %>">
+					<input type="datetime-local" id="ban_lift_date" name="ban_lift_date" value="<%= userSettings.ban_lift_date %>">
 				</div>
 				<div class="col">
 					<label class="labels">Ban Reason</label>


### PR DESCRIPTION
…ime instead of just the date

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #105 

### Changes:
Changed input-type="datetime-local", the ban panel will now show the time as according to this image 
![image](https://github.com/user-attachments/assets/dac8a9c6-a4c4-4fbe-97c8-ae0950ebfc82)
<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.